### PR TITLE
server.py:_parse_query_string: split only on first "="

### DIFF
--- a/phew/server.py
+++ b/phew/server.py
@@ -31,7 +31,7 @@ def urldecode(text):
 def _parse_query_string(query_string):
   result = {}
   for parameter in query_string.split("&"):
-    key, value = parameter.split("=")
+    key, value = parameter.split("=", 1)
     key = urldecode(key)
     value = urldecode(value)
     result[key] = value


### PR DESCRIPTION
Since form data is not URL encoded it may contain raw "=" characters.

Limit the key/value pair split only to the *first* occurrence of "=".

Potential fix for - https://github.com/pimoroni/enviro/issues/4