### PR TITLE
Create package.json for installation using mip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "urls": [
+    ["phew/__init__.py", "github:pimoroni/phew/phew/__init__.py"],
+    ["phew/dns.py", "github:pimoroni/phew/phew/dns.py"],
+    ["phew/logging.py", "github:pimoroni/phew/phew/logging.py"],
+    ["phew/ntp.py", "github:pimoroni/phew/phew/ntp.py"],
+    ["phew/server.py", "github:pimoroni/phew/phew/server.py"],
+    ["phew/template.py", "github:pimoroni/phew/phew/template.py"]
+  ],
+  "deps": [
+  ],
+  "version": "0.0.3"
+}


### PR DESCRIPTION
See https://docs.micropython.org/en/latest/reference/packages.html#writing-publishing-packages

Installing `phew` using `mip`:

    >>> import mip
    >>> mip.install("github:pimoroni/phew")
    Installing github:pimoroni/phew/package.json to /lib
    Copying: /lib/phew/__init__.py
    Copying: /lib/phew/dns.py
    Copying: /lib/phew/logging.py
    Copying: /lib/phew/ntp.py
    Copying: /lib/phew/server.py 
    Copying: /lib/phew/template.py
    Done
    >>> import phew
    >>> phew.is_connected_to_wifi()
    True