### PR TITLE
Fix messy log truncations

### DIFF
--- a/phew/logging.py
+++ b/phew/logging.py
@@ -62,8 +62,8 @@ def truncate(file, target_size):
 
       # try to find a line break nearby to split first chunk on
       break_position = max(
-        chunk.find (b"\n", -discard), # search forward
-        chunk.rfind(b"\n", -discard) # search backwards
+        chunk.find (b"\n", -discard),   # search forward
+        chunk.rfind(b"\n", 0, -discard) # search backwards
       )
       if break_position != -1: # if we found a line break..
         outfile.write(chunk[break_position + 1:])


### PR DESCRIPTION
The reverse search was going from the end of the file to `discard` pointer, which is the same range that is covered by the forward search. This sets the start of the reverse search to be the start of the chunk.

Without this change I was seeing the log file frequently start with a partial line.