### PR TITLE
Message in console if there was template expression error

### DIFF
--- a/phew/template.py
+++ b/phew/template.py
@@ -1,7 +1,8 @@
 from . import logging
+import sys
+import time
 
 async def render_template(template, **kwargs):
-  import time
   start_time = time.ticks_ms()
 
   with open(template, "rb") as f:
@@ -56,8 +57,10 @@ async def render_template(template, **kwargs):
           # yield the result of the expression
           if result is not None:
             yield str(result)
-      except:
-        pass
+      except Exception as e:
+        print(template)
+        print(expression)
+        sys.print_exception(e)
 
       # discard the parsed bit
       token_caret = end + 2


### PR DESCRIPTION
Show template file location, expression and error instead of failling silently. move 'import time' outside render_template() function