### PR TITLE
Add a method to write logs to the console only

### DIFF
--- a/phew/logging.py
+++ b/phew/logging.py
@@ -84,6 +84,10 @@ def log(level, text):
   datetime = datetime_string()
   log_entry = "{0} [{1:8} /{2:>4}kB] {3}".format(datetime, level, round(gc.mem_free() / 1024), text)
   print(log_entry)
+
+  if not log_file:
+    return
+
   with open(log_file, "a") as logfile:
     logfile.write(log_entry + '\n')
 


### PR DESCRIPTION
By default, the `logging` module logs to both console and the `log.txt` file. Since files are stored in flash memory on most devices running MicroPython, writing to the log file can wear the flash unnecessarily, especially when a large number of messages are written to the log.

Let's add a simple method to write log messages to the console only. By setting `logging.log_file` to `None`, the user can completely bypass writing log messages to the log file.