### PR TITLE
distinct instance of headers dict

### DIFF
--- a/phew/server.py
+++ b/phew/server.py
@@ -62,7 +62,9 @@ data: {self.data}"""
 
 
 class Response:
-  def __init__(self, body, status=200, headers={}):
+  def __init__(self, body, status=200, headers=None):
+    if headers is None:
+      headers = {}
     self.status = status
     self.headers = headers
     self.body = body


### PR DESCRIPTION
I found this bug when returning custom response headers.

the {} is declared once when you define the class and reused between instances, so once you return a specific header it will automatically end up on every request. 

Sorry I didn't open an issue first, I figured this was easier.